### PR TITLE
Enable Cloud Error Reporting integration in logger

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -51,9 +51,11 @@ func (s *Service) initializeLogger() error {
 	if runningInProduction() {
 		// Set up Google Cloud logging for production
 		s.Log, err = logger.NewGoogleCloudLogger(s.Context, logger.Config{
-			GCPProjectID: s.internal.config.GCPProjectID,
-			LogName:      "service-log",
-			Level:        slog.LevelInfo, // Use Info level for production
+			GCPProjectID:   s.internal.config.GCPProjectID,
+			LogName:        "service-log",
+			Level:          slog.LevelInfo, // Use Info level for production
+			ServiceName:    s.Name,
+			ServiceVersion: "1.0",
 		})
 	} else {
 		// Set up development logging for non-production environments

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -73,8 +73,10 @@ func NewGoogleCloudLogger(ctx context.Context, config Config) (*slog.Logger, err
 
 	// Create a custom slog handler for Google Cloud Logging
 	handler := &GoogleCloudLoggingHandler{
-		logger: googleLogger,
-		level:  config.Level, // Set the logging level based on the provided config
+		logger:         googleLogger,
+		level:          config.Level, // Set the logging level based on the provided config
+		serviceName:    config.ServiceName,
+		serviceVersion: config.ServiceVersion,
 	}
 
 	// Return a new slog.Logger using the custom Google Cloud Logging handler

--- a/pkg/logger/structs.go
+++ b/pkg/logger/structs.go
@@ -30,9 +30,11 @@ import (
 
 // Config holds configuration details for setting up logging.
 type Config struct {
-	GCPProjectID string     // GCPProjectID is the Google Cloud Project ID where logs will be sent.
-	LogName      string     // LogName is the name of the log stream where entries will be written.
-	Level        slog.Level // Level is the minimum log level that will be captured (e.g., DEBUG, INFO).
+	GCPProjectID   string     // GCPProjectID is the Google Cloud Project ID where logs will be sent.
+	ServiceName    string     // ServiceName identifies the service in Error Reporting and groups related errors together.
+	ServiceVersion string     // ServiceVersion specifies the version or revision of the service for Error Reporting.
+	LogName        string     // LogName is the name of the log stream where entries will be written.
+	Level          slog.Level // Level is the minimum log level that will be captured (e.g., DEBUG, INFO).
 }
 
 // DevelopmentHandler is a custom handler for slog used in development environments.
@@ -43,6 +45,8 @@ type DevelopmentHandler struct {
 
 // GoogleCloudLoggingHandler is a custom handler for slog used to send logs to Google Cloud Logging.
 type GoogleCloudLoggingHandler struct {
-	logger *logging.Logger // Logger is the Google Cloud Logger instance used to send log entries.
-	level  slog.Level      // Level is the minimum log level at which logs will be sent to Google Cloud.
+	logger         *logging.Logger // logger is the Google Cloud Logger instance used to send log entries.
+	level          slog.Level      // level is the minimum log level at which logs will be sent to Google Cloud.
+	serviceName    string          // serviceName identifies the service in Error Reporting and groups related errors together.
+	serviceVersion string          // serviceVersion specifies the version or revision of the service for Error Reporting.
 }


### PR DESCRIPTION
Add serviceContext and reportLocation fields to error logs so they are recognized by Google Cloud Error Reporting.

Also include stack traces for errors and configurable service name/version in logger Config.