### PR TITLE
Expand client disconnect detection for Cloud Run / HTTP/2

### DIFF
--- a/pkg/router/internal.go
+++ b/pkg/router/internal.go
@@ -23,11 +23,13 @@
 package router
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log"
 	"net"
 	"strings"
+	"syscall"
 )
 
 // awaitContextDone waits for the context's cancellation or completion signal (ctx.Done()).
@@ -41,14 +43,19 @@ func (r *Router) awaitContextDone() {
 }
 
 // isClientDisconnected checks if the given error is indicative of a client disconnection.
+// This covers TCP-level errors, HTTP/2 stream errors, and context cancellations that
+// occur on Cloud Run when a client drops the connection or a request times out.
 func isClientDisconnected(err error) bool {
 
 	if err == nil {
 		return false
 	}
 
-	// Check for specific error types or error messages
-	if errors.Is(err, io.EOF) {
+	// Check for specific well-known error types
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) {
 		return true
 	}
 
@@ -57,10 +64,20 @@ func isClientDisconnected(err error) bool {
 		return true
 	}
 
-	// Check error messages for common disconnection cases
+	// Check error messages for TCP and HTTP/2 disconnection cases
 	errMsg := strings.ToLower(err.Error())
-	if strings.Contains(errMsg, "broken pipe") || strings.Contains(errMsg, "connection reset by peer") {
-		return true
+	disconnectPatterns := []string{
+		"broken pipe",
+		"connection reset by peer",
+		"http2: stream closed",
+		"stream error",
+		"client disconnected",
+		"request canceled",
+	}
+	for _, pattern := range disconnectPatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
## Summary
- `isClientDisconnected()` only checked for TCP-level errors (broken pipe, connection reset, EOF, timeout)
- On Cloud Run with HTTP/2 (h2c), client disconnects produce different error signatures that weren't caught
- This caused spurious `"failed to send response"` errors appearing in GCP Error Reporting across all services

## Changes
Added detection for:
- `context.Canceled` — request context cancelled by client or Cloud Run proxy
- `syscall.EPIPE` / `syscall.ECONNRESET` — direct syscall error matching (more robust than string matching)
- HTTP/2 stream errors — `"http2: stream closed"`, `"stream error"`
- Client disconnection — `"client disconnected"`, `"request canceled"`

## Test plan
- [ ] Verify `go build ./pkg/router/` compiles without errors
- [ ] Deploy a service using this version and confirm "failed to send response" errors decrease in GCP Error Reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)