### PR TITLE
Fix: Configure SQL connection pool to prevent stale connections

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -135,6 +135,15 @@ func (s *Service) setupCloudSQL() (err error) {
 		return fmt.Errorf("failed to open connection: %w", err)
 	}
 
+	// Configure connection pool to handle Cloud SQL idle disconnects.
+	// Cloud SQL closes connections after ~10 minutes of inactivity.
+	// Without these settings, the pool serves stale connections that
+	// return "invalid connection" errors across all services.
+	s.DB.SetConnMaxLifetime(5 * time.Minute)
+	s.DB.SetConnMaxIdleTime(3 * time.Minute)
+	s.DB.SetMaxOpenConns(25)
+	s.DB.SetMaxIdleConns(5)
+
 	// Verify the connection to the database
 	if err := s.DB.Ping(); err != nil {
 		return fmt.Errorf("failed to ping database: %w", err)


### PR DESCRIPTION
## Problem

All services (push, ai, alerts, auth, cases, emails, billing, arbitrators, pdfs, postal) are simultaneously hitting `invalid connection` errors. Cloud SQL closes idle connections after ~10 minutes, but the Go `database/sql` pool has no lifetime/idle settings configured, so it serves stale connections.

## Fix

Added connection pool configuration after `sql.Open()`:

- `SetConnMaxLifetime(5 min)` — recycle connections before Cloud SQL's ~10 min idle timeout
- `SetConnMaxIdleTime(3 min)` — drop idle connections quickly
- `SetMaxOpenConns(25)` — prevent connection exhaustion
- `SetMaxIdleConns(5)` — keep a small warm pool

## Impact

This is a one-line-per-setting change in the shared service package. All services using `setupCloudSQL()` will automatically get healthy connection pooling on next deploy. No API or behavioral changes.